### PR TITLE
Add analytics script to Shipyard configuration

### DIFF
--- a/astro.config.js
+++ b/astro.config.js
@@ -91,6 +91,12 @@ export default defineConfig({
       title: 'Levin Keller',
       tagline: 'Levins Homepage',
       brand: 'Levin Keller',
+      scripts: [
+        {
+          src: 'https://analytics.levinkeller.de/js/script.js',
+          defer: true,
+        },
+      ],
     }),
     shipyardDocs(['docs']),
     shipyardBlog(['blog']),

--- a/astro.config.js
+++ b/astro.config.js
@@ -95,6 +95,7 @@ export default defineConfig({
         {
           src: 'https://analytics.levinkeller.de/js/script.js',
           defer: true,
+          'data-domain': 'levinkeller.de',
         },
       ],
     }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -3210,9 +3210,9 @@
       }
     },
     "node_modules/@levino/shipyard-base": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@levino/shipyard-base/-/shipyard-base-0.5.0.tgz",
-      "integrity": "sha512-3eGMLvkJyPqYrrx0mQvBDfrC2A9i1pvLc0rEMYDTGxA6ru6NXRn31Sp3Hibpx7pC0a2nFtUeofwuVxgCpyObBQ==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@levino/shipyard-base/-/shipyard-base-0.5.2.tgz",
+      "integrity": "sha512-CSr0LJP0GYCfW3KgOSPbFGInE4N3MdJScsXKTYTCZKOFkka5oCbFvyVNfCPOVVFS58pEyQokv5O+JEiVnRT6UA==",
       "dependencies": {
         "clsx": "^2.1.0",
         "ramda": "^0.29.1",


### PR DESCRIPTION
Adds analytics.levinkeller.de script with defer attribute to the Shipyard scripts array in astro.config.js.

Fixes #126

Generated with [Claude Code](https://claude.ai/code)