### PR TITLE
fix: Mark Digitalis purpurea as unsuccessful in plant list

### DIFF
--- a/content/blog/de/2025-08-18-staudenvorrat/index.mdx
+++ b/content/blog/de/2025-08-18-staudenvorrat/index.mdx
@@ -14,7 +14,7 @@ Ich habe es geschafft, folgende Stauden erfogreich auszusäen:
 - [Veronica longifolia (Langblättriger Ehrenpreis)](/de/garden/plants/veronica-longifolia) (wenige)
 - [Calamagrostis brachytricha (Diamant-Reitgras)](/de/garden/plants/calamagrostis-brachytricha)
 - [Miscanthus oligostachyus (Breitblatt-Chinaschilf)](/de/garden/plants/miscanthus-oligostachyus)
-- [Digitalis purpurea (Fingerhut)](/de/garden/plants/digitalis-purpurea)
+- ~~[Digitalis purpurea (Fingerhut)](/de/garden/plants/digitalis-purpurea)~~ (nichts geworden)
 - [Miscanthus sinensis (Chinaschilf)](/de/garden/plants/miscanthus-sinensis)
 - [Agastache foeniculum (Fenchel-Agastache)](/de/garden/plants/agastache-foeniculum)
 - [Francoa sonchifolia](/de/garden/plants/francoa-sonchifolia)


### PR DESCRIPTION
Updates the Staudenvorrat blog post to indicate that Digitalis purpurea (Fingerhut) didn't work out by striking through the text and adding 'nichts geworden' note.

Fixes #144

Generated with [Claude Code](https://claude.ai/code)