### PR TITLE
feat: Add Google Image search links to plant pages

### DIFF
--- a/src/components/garden/Plant/index.tsx
+++ b/src/components/garden/Plant/index.tsx
@@ -59,11 +59,12 @@ export const Plant: FC<PropsWithChildren<Props>> = ({ plant, children }) => (
         href={`https://www.google.com/search?tbm=isch&q=${encodeURIComponent(plant.data.name.latin)}`}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex items-center gap-1 px-3 py-1 text-sm bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
+        className="btn btn-sm"
         title={`Bilder von ${plant.data.name.latin} auf Google suchen`}
+        aria-label={`Bilder von ${plant.data.name.latin} auf Google suchen`}
       >
         <IconSearch className="w-4 h-4" />
-        <span>Bilder suchen</span>
+        Bilder suchen
       </a>
     </div>
     <h2 className="text-xl">{plant.data.name.german}</h2>

--- a/src/components/garden/Plant/index.tsx
+++ b/src/components/garden/Plant/index.tsx
@@ -1,5 +1,5 @@
-import type { CollectionEntry } from "astro:content";
-import { MONTHS_DE, MONTHS_EN } from "@levino/shipyard-base";
+import type { CollectionEntry } from 'astro:content'
+import { MONTHS_DE, MONTHS_EN } from '@levino/shipyard-base'
 import {
   IconCactus,
   IconDroplet,
@@ -8,48 +8,48 @@ import {
   IconFlower,
   IconMoon,
   IconPalette,
+  IconSearch,
   IconSeeding,
   IconSun,
   IconSunMoon,
-  IconSearch,
-} from "@tabler/icons-react";
-import type { FC, PropsWithChildren } from "react";
+} from '@tabler/icons-react'
+import type { FC, PropsWithChildren } from 'react'
 
-type Props = { plant: CollectionEntry<"plants"> };
+type Props = { plant: CollectionEntry<'plants'> }
 
 const flowerColorMap: Record<string, string> = {
-  "wine-red": "#722F37",
-  red: "#DC143C",
-  blue: "#4169E1",
-  yellow: "#FFD700",
-  white: "#FFFFFF",
-  pink: "#FFC0CB",
-  green: "#228B22",
-  brown: "#8B4513",
-  orange: "#FF8C00",
-  violet: "#8B7AB8",
-  rose: "#FF007F",
-  black: "#1C1C1C",
-  purple: "#800080",
-  cream: "#FFFDD0",
-};
+  'wine-red': '#722F37',
+  red: '#DC143C',
+  blue: '#4169E1',
+  yellow: '#FFD700',
+  white: '#FFFFFF',
+  pink: '#FFC0CB',
+  green: '#228B22',
+  brown: '#8B4513',
+  orange: '#FF8C00',
+  violet: '#8B7AB8',
+  rose: '#FF007F',
+  black: '#1C1C1C',
+  purple: '#800080',
+  cream: '#FFFDD0',
+}
 
 const flowerColorNames: Record<string, string> = {
-  "wine-red": "Weinrot",
-  red: "Rot",
-  blue: "Blau",
-  yellow: "Gelb",
-  white: "Weiß",
-  pink: "Rosa",
-  green: "Grün",
-  brown: "Braun",
-  orange: "Orange",
-  violet: "Violett",
-  rose: "Rose",
-  black: "Schwarz",
-  purple: "Lila",
-  cream: "Creme",
-};
+  'wine-red': 'Weinrot',
+  red: 'Rot',
+  blue: 'Blau',
+  yellow: 'Gelb',
+  white: 'Weiß',
+  pink: 'Rosa',
+  green: 'Grün',
+  brown: 'Braun',
+  orange: 'Orange',
+  violet: 'Violett',
+  rose: 'Rose',
+  black: 'Schwarz',
+  purple: 'Lila',
+  cream: 'Creme',
+}
 
 export const Plant: FC<PropsWithChildren<Props>> = ({ plant, children }) => (
   <div className="py-4">
@@ -93,7 +93,7 @@ export const Plant: FC<PropsWithChildren<Props>> = ({ plant, children }) => (
     <PlantTable plant={plant} />
     <div className="py-4">{children}</div>
   </div>
-);
+)
 
 const FlowerColors: FC<Props> = ({ plant }) => (
   <div className="stats shadow w-full mt-4">
@@ -111,7 +111,7 @@ const FlowerColors: FC<Props> = ({ plant }) => (
             >
               <div
                 className="h-4 w-4 rounded-full border border-gray-400"
-                style={{ backgroundColor: flowerColorMap[color] || "#CCCCCC" }}
+                style={{ backgroundColor: flowerColorMap[color] || '#CCCCCC' }}
               />
               <span className="text-sm">
                 {flowerColorNames[color] ?? color}
@@ -122,7 +122,7 @@ const FlowerColors: FC<Props> = ({ plant }) => (
       </div>
     </div>
   </div>
-);
+)
 
 const Sun: FC<Props> = ({ plant }) => (
   <div className="stat">
@@ -134,66 +134,66 @@ const Sun: FC<Props> = ({ plant }) => (
       ))}
     </div>
   </div>
-);
+)
 
 const ExposureBadge: FC<{
-  sunExposure: "full" | "semi-shade" | "shade" | "light-shade";
+  sunExposure: 'full' | 'semi-shade' | 'shade' | 'light-shade'
 }> = ({ sunExposure }) => {
   switch (sunExposure) {
-    case "full":
+    case 'full':
       return (
         <div className="tooltip" data-tip="sonnig">
           <IconSun />
         </div>
-      );
-    case "semi-shade":
+      )
+    case 'semi-shade':
       return (
         <div className="tooltip" data-tip="halbschattig">
           <IconSunMoon />
         </div>
-      );
-    case "shade":
+      )
+    case 'shade':
       return (
         <div className="tooltip" data-tip="schattig">
           <IconMoon />
         </div>
-      );
-    case "light-shade":
+      )
+    case 'light-shade':
       return (
         <div className="tooltip" data-tip="Lichter Schatten">
           <IconMoon />
         </div>
-      );
+      )
   }
-};
+}
 
 const Soil: FC<Props> = ({ plant }) => (
   <div className="stat">
     <div className="stat-title">Boden</div>
     <div className="stat-value">
-      {plant.data.soil.includes("moist") && (
+      {plant.data.soil.includes('moist') && (
         <div className="tooltip" data-tip="feucht">
           <IconDropletHalf2Filled />
         </div>
       )}
-      {plant.data.soil.includes("dry") && (
+      {plant.data.soil.includes('dry') && (
         <div className="tooltip" data-tip="trocken">
           <IconCactus />
         </div>
       )}
-      {plant.data.soil.includes("normal") && (
+      {plant.data.soil.includes('normal') && (
         <div className="tooltip" data-tip="normal">
           <IconDroplet />
         </div>
       )}
-      {plant.data.soil.includes("wet") && (
+      {plant.data.soil.includes('wet') && (
         <div className="tooltip" data-tip="nass">
           <IconDropletFilled />
         </div>
       )}
     </div>
   </div>
-);
+)
 
 const Dimensions: FC<Props> = ({ plant }) => [
   <div key="height" className="stat">
@@ -204,7 +204,7 @@ const Dimensions: FC<Props> = ({ plant }) => [
     <div className="stat-title">Breite</div>
     <div className="stat-value">{plant.data.spread} cm</div>
   </div>,
-];
+]
 
 const PlantTable: FC<Props> = ({ plant }) => (
   <div className="overflow-x-auto mt-4">
@@ -232,12 +232,12 @@ const PlantTable: FC<Props> = ({ plant }) => (
                 <td key={key} className="border border-slate-400 py-1 sm:py-2">
                   <IconFlower className="mx-auto h-4 w-4 sm:h-6 sm:w-6" />
                 </td>
-              );
+              )
             }
             return (
               // biome-ignore lint/suspicious/noArrayIndexKey: Did not find a better key here
               <td key={key} className="border border-slate-400 py-1 sm:py-2" />
-            );
+            )
           })}
         </tr>
         <tr>
@@ -248,15 +248,15 @@ const PlantTable: FC<Props> = ({ plant }) => (
                 <td key={key} className="border border-slate-400 py-1 sm:py-2">
                   <IconSeeding className="mx-auto h-4 w-4 sm:h-6 sm:w-6" />
                 </td>
-              );
+              )
             }
             return (
               // biome-ignore lint/suspicious/noArrayIndexKey: Did not find a better key here
               <td key={key} className="border border-slate-400 py-1 sm:py-2" />
-            );
+            )
           })}
         </tr>
       </tbody>
     </table>
   </div>
-);
+)

--- a/src/components/garden/Plant/index.tsx
+++ b/src/components/garden/Plant/index.tsx
@@ -1,5 +1,5 @@
-import type { CollectionEntry } from 'astro:content'
-import { MONTHS_DE, MONTHS_EN } from '@levino/shipyard-base'
+import type { CollectionEntry } from "astro:content";
+import { MONTHS_DE, MONTHS_EN } from "@levino/shipyard-base";
 import {
   IconCactus,
   IconDroplet,
@@ -11,48 +11,61 @@ import {
   IconSeeding,
   IconSun,
   IconSunMoon,
-} from '@tabler/icons-react'
-import type { FC, PropsWithChildren } from 'react'
+  IconSearch,
+} from "@tabler/icons-react";
+import type { FC, PropsWithChildren } from "react";
 
-type Props = { plant: CollectionEntry<'plants'> }
+type Props = { plant: CollectionEntry<"plants"> };
 
 const flowerColorMap: Record<string, string> = {
-  'wine-red': '#722F37',
-  red: '#DC143C',
-  blue: '#4169E1',
-  yellow: '#FFD700',
-  white: '#FFFFFF',
-  pink: '#FFC0CB',
-  green: '#228B22',
-  brown: '#8B4513',
-  orange: '#FF8C00',
-  violet: '#8B7AB8',
-  rose: '#FF007F',
-  black: '#1C1C1C',
-  purple: '#800080',
-  cream: '#FFFDD0',
-}
+  "wine-red": "#722F37",
+  red: "#DC143C",
+  blue: "#4169E1",
+  yellow: "#FFD700",
+  white: "#FFFFFF",
+  pink: "#FFC0CB",
+  green: "#228B22",
+  brown: "#8B4513",
+  orange: "#FF8C00",
+  violet: "#8B7AB8",
+  rose: "#FF007F",
+  black: "#1C1C1C",
+  purple: "#800080",
+  cream: "#FFFDD0",
+};
 
 const flowerColorNames: Record<string, string> = {
-  'wine-red': 'Weinrot',
-  red: 'Rot',
-  blue: 'Blau',
-  yellow: 'Gelb',
-  white: 'Weiß',
-  pink: 'Rosa',
-  green: 'Grün',
-  brown: 'Braun',
-  orange: 'Orange',
-  violet: 'Violett',
-  rose: 'Rose',
-  black: 'Schwarz',
-  purple: 'Lila',
-  cream: 'Creme',
-}
+  "wine-red": "Weinrot",
+  red: "Rot",
+  blue: "Blau",
+  yellow: "Gelb",
+  white: "Weiß",
+  pink: "Rosa",
+  green: "Grün",
+  brown: "Braun",
+  orange: "Orange",
+  violet: "Violett",
+  rose: "Rose",
+  black: "Schwarz",
+  purple: "Lila",
+  cream: "Creme",
+};
 
 export const Plant: FC<PropsWithChildren<Props>> = ({ plant, children }) => (
   <div className="py-4">
-    <h1 className="text-3xl font-bold">{plant.data.name.latin}</h1>
+    <div className="flex items-center gap-3">
+      <h1 className="text-3xl font-bold">{plant.data.name.latin}</h1>
+      <a
+        href={`https://www.google.com/search?tbm=isch&q=${encodeURIComponent(plant.data.name.latin)}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1 px-3 py-1 text-sm bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
+        title={`Bilder von ${plant.data.name.latin} auf Google suchen`}
+      >
+        <IconSearch className="w-4 h-4" />
+        <span>Bilder suchen</span>
+      </a>
+    </div>
     <h2 className="text-xl">{plant.data.name.german}</h2>
     <div className="stats stats-vertical sm:stats-horizontal shadow w-full">
       <Dimensions plant={plant} />
@@ -79,7 +92,7 @@ export const Plant: FC<PropsWithChildren<Props>> = ({ plant, children }) => (
     <PlantTable plant={plant} />
     <div className="py-4">{children}</div>
   </div>
-)
+);
 
 const FlowerColors: FC<Props> = ({ plant }) => (
   <div className="stats shadow w-full mt-4">
@@ -97,7 +110,7 @@ const FlowerColors: FC<Props> = ({ plant }) => (
             >
               <div
                 className="h-4 w-4 rounded-full border border-gray-400"
-                style={{ backgroundColor: flowerColorMap[color] || '#CCCCCC' }}
+                style={{ backgroundColor: flowerColorMap[color] || "#CCCCCC" }}
               />
               <span className="text-sm">
                 {flowerColorNames[color] ?? color}
@@ -108,7 +121,7 @@ const FlowerColors: FC<Props> = ({ plant }) => (
       </div>
     </div>
   </div>
-)
+);
 
 const Sun: FC<Props> = ({ plant }) => (
   <div className="stat">
@@ -120,66 +133,66 @@ const Sun: FC<Props> = ({ plant }) => (
       ))}
     </div>
   </div>
-)
+);
 
 const ExposureBadge: FC<{
-  sunExposure: 'full' | 'semi-shade' | 'shade' | 'light-shade'
+  sunExposure: "full" | "semi-shade" | "shade" | "light-shade";
 }> = ({ sunExposure }) => {
   switch (sunExposure) {
-    case 'full':
+    case "full":
       return (
         <div className="tooltip" data-tip="sonnig">
           <IconSun />
         </div>
-      )
-    case 'semi-shade':
+      );
+    case "semi-shade":
       return (
         <div className="tooltip" data-tip="halbschattig">
           <IconSunMoon />
         </div>
-      )
-    case 'shade':
+      );
+    case "shade":
       return (
         <div className="tooltip" data-tip="schattig">
           <IconMoon />
         </div>
-      )
-    case 'light-shade':
+      );
+    case "light-shade":
       return (
         <div className="tooltip" data-tip="Lichter Schatten">
           <IconMoon />
         </div>
-      )
+      );
   }
-}
+};
 
 const Soil: FC<Props> = ({ plant }) => (
   <div className="stat">
     <div className="stat-title">Boden</div>
     <div className="stat-value">
-      {plant.data.soil.includes('moist') && (
+      {plant.data.soil.includes("moist") && (
         <div className="tooltip" data-tip="feucht">
           <IconDropletHalf2Filled />
         </div>
       )}
-      {plant.data.soil.includes('dry') && (
+      {plant.data.soil.includes("dry") && (
         <div className="tooltip" data-tip="trocken">
           <IconCactus />
         </div>
       )}
-      {plant.data.soil.includes('normal') && (
+      {plant.data.soil.includes("normal") && (
         <div className="tooltip" data-tip="normal">
           <IconDroplet />
         </div>
       )}
-      {plant.data.soil.includes('wet') && (
+      {plant.data.soil.includes("wet") && (
         <div className="tooltip" data-tip="nass">
           <IconDropletFilled />
         </div>
       )}
     </div>
   </div>
-)
+);
 
 const Dimensions: FC<Props> = ({ plant }) => [
   <div key="height" className="stat">
@@ -190,7 +203,7 @@ const Dimensions: FC<Props> = ({ plant }) => [
     <div className="stat-title">Breite</div>
     <div className="stat-value">{plant.data.spread} cm</div>
   </div>,
-]
+];
 
 const PlantTable: FC<Props> = ({ plant }) => (
   <div className="overflow-x-auto mt-4">
@@ -218,12 +231,12 @@ const PlantTable: FC<Props> = ({ plant }) => (
                 <td key={key} className="border border-slate-400 py-1 sm:py-2">
                   <IconFlower className="mx-auto h-4 w-4 sm:h-6 sm:w-6" />
                 </td>
-              )
+              );
             }
             return (
               // biome-ignore lint/suspicious/noArrayIndexKey: Did not find a better key here
               <td key={key} className="border border-slate-400 py-1 sm:py-2" />
-            )
+            );
           })}
         </tr>
         <tr>
@@ -234,15 +247,15 @@ const PlantTable: FC<Props> = ({ plant }) => (
                 <td key={key} className="border border-slate-400 py-1 sm:py-2">
                   <IconSeeding className="mx-auto h-4 w-4 sm:h-6 sm:w-6" />
                 </td>
-              )
+              );
             }
             return (
               // biome-ignore lint/suspicious/noArrayIndexKey: Did not find a better key here
               <td key={key} className="border border-slate-400 py-1 sm:py-2" />
-            )
+            );
           })}
         </tr>
       </tbody>
     </table>
   </div>
-)
+);

--- a/src/components/garden/PlantTable.tsx
+++ b/src/components/garden/PlantTable.tsx
@@ -31,8 +31,9 @@ export const PlantTable: FC<{
                 href={`https://www.google.com/search?tbm=isch&q=${encodeURIComponent(plant.data.name.latin)}`}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-gray-500 hover:text-gray-700"
+                className="btn btn-ghost btn-xs"
                 title={`Bilder von ${plant.data.name.latin} auf Google suchen`}
+                aria-label={`Bilder von ${plant.data.name.latin} auf Google suchen`}
               >
                 <MagnifyingGlassIcon className="w-4 h-4" />
               </a>

--- a/src/components/garden/PlantTable.tsx
+++ b/src/components/garden/PlantTable.tsx
@@ -1,14 +1,14 @@
-import type { CollectionEntry } from "astro:content";
+import type { CollectionEntry } from 'astro:content'
 import {
   CheckIcon,
   Cross2Icon,
   MagnifyingGlassIcon,
-} from "@radix-ui/react-icons";
-import type { FC } from "react";
+} from '@radix-ui/react-icons'
+import type { FC } from 'react'
 
 export const PlantTable: FC<{
-  plants: CollectionEntry<"plants">[];
-  caption: string;
+  plants: CollectionEntry<'plants'>[]
+  caption: string
 }> = ({ plants, caption }) => (
   <table className="table">
     <p>{caption}</p>
@@ -45,4 +45,4 @@ export const PlantTable: FC<{
       ))}
     </tbody>
   </table>
-);
+)

--- a/src/components/garden/PlantTable.tsx
+++ b/src/components/garden/PlantTable.tsx
@@ -1,10 +1,14 @@
-import type { CollectionEntry } from 'astro:content'
-import { CheckIcon, Cross2Icon } from '@radix-ui/react-icons'
-import type { FC } from 'react'
+import type { CollectionEntry } from "astro:content";
+import {
+  CheckIcon,
+  Cross2Icon,
+  MagnifyingGlassIcon,
+} from "@radix-ui/react-icons";
+import type { FC } from "react";
 
 export const PlantTable: FC<{
-  plants: CollectionEntry<'plants'>[]
-  caption: string
+  plants: CollectionEntry<"plants">[];
+  caption: string;
 }> = ({ plants, caption }) => (
   <table className="table">
     <p>{caption}</p>
@@ -19,9 +23,20 @@ export const PlantTable: FC<{
       {plants.map((plant) => (
         <tr key={plant.id}>
           <th>
-            <a href={`/de/garden/plants/${plant.id}`}>
-              {plant.data.name.latin}
-            </a>
+            <div className="flex items-center gap-2">
+              <a href={`/de/garden/plants/${plant.id}`}>
+                {plant.data.name.latin}
+              </a>
+              <a
+                href={`https://www.google.com/search?tbm=isch&q=${encodeURIComponent(plant.data.name.latin)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-gray-500 hover:text-gray-700"
+                title={`Bilder von ${plant.data.name.latin} auf Google suchen`}
+              >
+                <MagnifyingGlassIcon className="w-4 h-4" />
+              </a>
+            </div>
           </th>
           <td>{plant.data.name.german}</td>
           <td>{plant.data.inStock ? <CheckIcon /> : <Cross2Icon />}</td>
@@ -29,4 +44,4 @@ export const PlantTable: FC<{
       ))}
     </tbody>
   </table>
-)
+);


### PR DESCRIPTION
Closes #148

Added Google Image search links for each plant using Latin names:
- PlantTable component: Added search icon next to Latin names
- Plant detail component: Added "Bilder suchen" button next to heading
- Links open Google Image search in new tab with Latin name query

Generated with [Claude Code](https://claude.ai/code)