### PR TITLE
fix: Mark Digitalis purpurea as unsuccessful in plant list

### DIFF
--- a/content/blog/de/2025-08-18-staudenvorrat/index.mdx
+++ b/content/blog/de/2025-08-18-staudenvorrat/index.mdx
@@ -20,7 +20,7 @@ Ich habe es geschafft, folgende Stauden erfogreich auszusäen:
 - [Aster novi-belgii (Glattblattaster)](/de/garden/plants/aster-novi-belgii)
 - [Astrantia major (Große Sterndolde)](/de/garden/plants/astrantia-major)
 - [Calamagrostis brachytricha (Diamant-Reitgras)](/de/garden/plants/calamagrostis-brachytricha)
-- [Digitalis purpurea (Fingerhut)](/de/garden/plants/digitalis-purpurea)
+- ~~[Digitalis purpurea (Fingerhut)](/de/garden/plants/digitalis-purpurea)~~ (nichts geworden)
 - [Dipsacus sylvestris (Wilde Karde)](/de/garden/plants/dipsacus-sylvestris)
 - [Dracocephalum ruyschiana (Drachenkopf)](/de/garden/plants/dracocephalum-ruyschiana)
 - [Francoa sonchifolia](/de/garden/plants/francoa-sonchifolia)


### PR DESCRIPTION
Updates the Staudenvorrat blog post to indicate that Digitalis purpurea (Fingerhut) didn't work out by striking through the text and adding 'nichts geworden' note.

Fixes #144

Generated with [Claude Code](https://claude.ai/code)