### PR TITLE
Veröffentliche offenen Brief zum Fernwärmenetz Adensen

### DIFF
--- a/content/docs/de/studies/fernwaerme-adensen-offener-brief.md
+++ b/content/docs/de/studies/fernwaerme-adensen-offener-brief.md
@@ -4,11 +4,11 @@
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path></svg>
   <div>
     <h3 class="font-bold">Offener Brief</h3>
-    <p>Dies ist ein offener Brief, der am 13.10.2025 an den Ersten Gemeinderat Niemann und die Ratsmitglieder der Gemeinde Nordstemmen versendet wurde.</p>
+    <p>Dies ist ein offener Brief, der am 13.10.2025 an Herrn Niemann (Leiter Fachbereich 1) und die Ratsmitglieder der Gemeinde Nordstemmen versendet wurde.</p>
   </div>
 </div>
 
-## An den Ersten Gemeinderat Herrn Niemann und die Mitglieder des Rates der Gemeinde Nordstemmen
+## An Herrn Niemann (Leiter Fachbereich 1) und die Mitglieder des Rates der Gemeinde Nordstemmen
 
 Sehr geehrter Herr Niemann,
 


### PR DESCRIPTION
## Summary

Dieser Pull Request fügt einen offenen Brief vom 13.10.2025 zum Wissensbereich hinzu, der sich mit der geplanten kommunalen Beteiligung der Gemeinde Nordstemmen am Fernwärmenetz in Adensen auseinandersetzt.

## Änderungen

- Neues Dokument: `content/docs/de/studies/fernwaerme-adensen-offener-brief.md`
- Der Brief adressiert den Ersten Gemeinderat und die Ratsmitglieder
- Enthält kritische Fragen zur Wirtschaftlichkeit, zu Vertragslaufzeiten und Risiken
- Verlinkt zur bestehenden Case Study über das Fernwärmenetz Adensen

## Kontext

Der offene Brief wurde einen Tag vor der entscheidenden Ratssitzung am 14.10.2025 versendet und ergänzt die bereits vorhandene Recherche-Dokumentation zum Verwaltungsvorgang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)