### PR TITLE
Add blog post about garlic planting

### DIFF
--- a/content/blog/de/2026-01-02-knoblauch-gesteckt/index.mdx
+++ b/content/blog/de/2026-01-02-knoblauch-gesteckt/index.mdx
@@ -1,0 +1,16 @@
+---
+title: Knoblauch gesteckt
+authors:
+  - name: Levin Keller
+description: 120 Knoblauchzehen gesteckt und Beete auf 1,20 m erweitert - ein später Versuch.
+date: 2026-01-02
+tags: [gardening]
+---
+
+Heute habe ich 120 Knoblauchzehen gesteckt. Außerdem habe ich meine Beete auf 1,20 m Breite erweitert.
+
+## Später Zeitpunkt
+
+Eigentlich ist Anfang Januar sehr spät, um Knoblauch zu stecken - manche würden sagen: zu spät. Normalerweise sollte Knoblauch im Herbst (Oktober/November) in die Erde, damit er vor dem Winter noch Wurzeln bilden kann. Ich bin vorher einfach nicht dazu gekommen.
+
+Wir werden sehen, ob es trotzdem klappt. Ein Experiment.


### PR DESCRIPTION
Document planting 120 garlic cloves on January 2nd, 2026 and expanding beds to 1.20m width. Notes that this is a late experiment since garlic is usually planted in autumn.