### PR TITLE
Deutsche Texte verbessern und Garten-UI lokalisieren

### DIFF
--- a/src/pages/[locale]/garden/plants/[...slug].astro
+++ b/src/pages/[locale]/garden/plants/[...slug].astro
@@ -41,7 +41,7 @@ const Description = await Effect.runPromiseExit(getDescription)
       Exit.isSuccess(Description) ? (
         <Description.value />
       ) : (
-        <p>There is no description for this plant yet.</p>
+        <p>Für diese Pflanze gibt es bisher noch keine Beschreibung.</p>
       )
     }
   </div>

--- a/src/pages/[locale]/garden/plants/[page].astro
+++ b/src/pages/[locale]/garden/plants/[page].astro
@@ -20,7 +20,7 @@ const { page } = Astro.props
   <div class="mt-8">
     <PlantTable caption="Stauden" plants={page.data} />
 
-    {page.url.prev ? <a href={page.url.prev}>Previous</a> : null}
-    {page.url.next ? <a href={page.url.next}>Next</a> : null}
+    {page.url.prev ? <a href={page.url.prev}>Zurück</a> : null}
+    {page.url.next ? <a href={page.url.next}>Weiter</a> : null}
   </div>
 </Layout>

--- a/src/pages/de/about.md
+++ b/src/pages/de/about.md
@@ -1,11 +1,11 @@
 ---
-title: Über meine Homepage
+title: Über meine Website
 layout: '@levino/shipyard-base/layouts/Markdown.astro'
 ---
 
 # Über levinkeller.de
 
-Ich betreibe diese Homepage aus verschiedenen Gründen, die ich hier erläutern
+Ich betreibe diese Website aus verschiedenen Gründen, die ich hier erläutern
 möchte.
 
 ## Öffentliches Notiz- und Tagebuch
@@ -20,21 +20,21 @@ und [github](https://github.com/) erlaubt mir, die Informationen ansprechend und
 übersichtlich abzulegen und den Prozess und die Historie nachhaltig zu
 dokumentieren.
 
-## Showcase für meine Arbeit
+## Schaufenster für meine Arbeit
 
 Ich arbeite als selbstständiger Software-Entwickler und der Quellcode dieser
 Webseite, inklusive aller Inhalte, ist
 [öffentlich](https://github.com/levino/levinkeller.de) auf github zugänglich.
 Jede Person kann mich bei meiner Arbeit an dieser Webseite beobachten und mit
 genug Fachkenntnis die Qualität meiner Arbeit und sogar meine Arbeitsweise
-prüfen und bewerten. Normalerweise arbeite ich "über den Stack", was heißt, dass
-ich nicht nur Code schreibe, der die Darstellung des User-Interfaces betrifft
-(front end), sondern auch Code für den Server, die Datenbanken und alle anderen
+prüfen und bewerten. Normalerweise arbeite ich "über den gesamten Stack", was
+heißt, dass ich nicht nur Code für die Benutzeroberfläche (Frontend) schreibe,
+sondern auch für den Server, die Datenbanken und alle anderen
 Bereiche schreibe, die man für den Betrieb von großen Softwareprojekten
 benötigt. Meistens schreibe ich auch keinen Code, sondern koordiniere die Arbeit
 von Software-Entwickler:innen und konzipiere die Architektur. Die Technologien,
 die ich für das Erstellen dieser Webseite benötige, sind grundsätzlich dem
-Bereich front end zuzuordnen. Insofern erhält man durch diese Webseite nur einen
+Bereich Frontend zuzuordnen. Insofern erhält man durch diese Webseite nur einen
 Einblick in einen Teil meiner Arbeit, aber viele der Muster und Methoden sind
 auch auf die anderen Bereiche übertragbar.
 
@@ -44,14 +44,14 @@ Alle Inhalte dieser Webseite und auch der Quellcode unterliegen der
 [MIT-Lizenz](https://de.wikipedia.org/wiki/MIT-Lizenz) für geistiges Eigentum.
 Jede Person kann die Inhalte kopieren und für eigene Projekte nutzen, ohne jede
 Einschränkungen. Gratis. Selbst meine Urheberschaft muss nicht erwähnt werden.
-Ich mache das, weil ich überzeugt davon bin, dass wir mit Open-Source eine
+Ich mache das, weil ich überzeugt davon bin, dass wir mit Open Source eine
 bessere Welt erreichen können. Sollte ich Inhalte produzieren, die für andere
-für ihr Projekt nutzen können und im Idealfall weitere wertvolle Inhalte mit
+für ihr Projekt nützlich sind und im Idealfall weitere wertvolle Inhalte aus
 meinen Beiträgen generieren, haben alle gewonnen. Dafür ist es wichtig, dass die
-Unterlagen möglichst in Ihrer Reinform bzw. strukturiert vorliegen und
+Unterlagen möglichst in ihrer Rohform beziehungsweise strukturiert vorliegen und
 entsprechend einfach weiter verarbeitet werden können. Dies garantiert die
-Verwendung von [markdown](https://de.wikipedia.org/wiki/Markdown), git und
-github. Ich hoffe, dass es in Zukunft noch viel mehr Menschen gibt, die
+Verwendung von [Markdown](https://de.wikipedia.org/wiki/Markdown), Git und
+GitHub. Ich hoffe, dass es in Zukunft noch viel mehr Menschen gibt, die
 Internetseiten auf diese Art und Weise bauen, sodass ich mich auch bei Ihnen
 bedienen kann, um mithilfe Ihrer Arbeit meine Arbeit zu erleichtern und zu
 beschleunigen.

--- a/src/pages/de/index.mdx
+++ b/src/pages/de/index.mdx
@@ -3,17 +3,16 @@ layout: '@levino/shipyard-base/layouts/Splash.astro'
 title: Startseite
 locale: de
 description:
-  Unsortierte Inhalte zu Garten, Politik, Code und allem, was sonst so
+  Unsortierte Inhalte zu Garten, Politik, Software und allem, was sonst so
   interessant ist.
 ---
 
 import { Card } from '@/components/Card'
 
-Willkommen auf meiner Homepage. Diese Seite wird lean entwickelt, insofern sind
-hier noch wenige Inhalte und viele Dinge unvollständig oder ästhetisch nicht
-stimmig. Außerdem ermöglicht mir diese Seite ein bisschen mit
-[astro](https://astro.build/), content collections und MDX herumzuspielen, was
-interessant ist.
+Willkommen auf meiner Website. Diese Seite wird schrittweise entwickelt, daher
+gibt es aktuell noch wenige Inhalte und einige Bereiche sind unvollständig oder
+gestalterisch noch nicht ganz stimmig. Gleichzeitig nutze ich die Seite, um mit
+[Astro](https://astro.build/), Content Collections und MDX zu experimentieren.
 
 <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
   <Card

--- a/src/pages/de/work.astro
+++ b/src/pages/de/work.astro
@@ -8,13 +8,13 @@ const title = 'Projekte & Portfolio'
 <Layout {title}>
   <div class="container mx-auto px-4 py-8">
     <div class="prose max-w-none">
-      <h2>Freelance Software-Entwicklung</h2>
+      <h2>Freiberufliche Software-Entwicklung</h2>
       <p>
         Ich bin freier Software-Entwickler. Bitte sprechen Sie mich an, wenn Sie
         Unterstützung in Ihrem Projekt benötigen.
       </p>
 
-      <h2>Open Source</h2>
+      <h2>Open-Source-Projekte</h2>
       <p>
         Einige meiner Open-Source-Projekte, die ich entwickelt habe und pflege.
       </p>
@@ -28,7 +28,7 @@ const title = 'Projekte & Portfolio'
           Ein modulares Astro-Framework zum schnellen Erstellen von Websites. Es
           bietet fertige Layouts, Komponenten und Konfigurationen für Blogs,
           Dokumentation und Landing Pages. Shipyard nutzt DaisyUI für
-          konsistentes Styling und unterstützt Mehrsprachigkeit out-of-the-box.
+          konsistentes Styling und unterstützt Mehrsprachigkeit von Haus aus.
         </Fragment>
         <Fragment slot="motivation">
           <p>
@@ -55,8 +55,8 @@ const title = 'Projekte & Portfolio'
       >
         <Fragment slot="description">
           Eine Bibliothek zum Testen von JWT-Authentifizierung in Node.js. Sie
-          erstellt einen Mock-JWKS-Server, der JWTs signiert und validiert -
-          ideal für Integration Tests ohne echten Identity Provider.
+          erstellt einen JWKS-Testserver, der JWTs signiert und validiert –
+          ideal für Integrationstests ohne echten Identitätsanbieter.
         </Fragment>
         <Fragment slot="motivation">
           Beim Testen von APIs mit JWT-Auth fehlte mir ein einfaches Tool. Diese
@@ -78,14 +78,14 @@ const title = 'Projekte & Portfolio'
       >
         <Fragment slot="description">
           Ein Programmierkurs für Kinder, der echte Entwickler-Tools vermittelt.
-          Kein Scratch oder Spielzeug-Beispiele, sondern Git, GitHub, VS Code
-          und Web-Entwicklung mit React und Astro. Asynchrones Lernen im eigenen
-          Tempo mit regelmäßigen Gruppen-Sessions.
+          Keine Scratch- oder Spielzeugbeispiele, sondern Git, GitHub, VS Code
+          und Webentwicklung mit React und Astro. Asynchrones Lernen im eigenen
+          Tempo mit regelmäßigen Gruppenterminen.
         </Fragment>
         <Fragment slot="motivation">
           Ich wollte Kindern aus meinem Umfeld zeigen, wie Software-Entwicklung
           wirklich funktioniert. Statt vereinfachter Lernumgebungen arbeiten wir
-          mit den gleichen Tools, die Profis nutzen - das motiviert und bereitet
+          mit den gleichen Werkzeugen, die Profis nutzen – das motiviert und bereitet
           auf echte Projekte vor.
         </Fragment>
       </PortfolioCard>
@@ -189,7 +189,7 @@ const title = 'Projekte & Portfolio'
         <Fragment slot="description">
           Visualisierung des Gemeindehaushalts mit Sankey-Diagrammen. Die Seite
           zeigt Einnahmen, Ausgaben und Finanzströme der Gemeinde Nordstemmen
-          über mehrere Jahre - komplett statisch generiert.
+          über mehrere Jahre – vollständig statisch generiert.
         </Fragment>
         <Fragment slot="motivation">
           Haushaltsdaten sind öffentlich, aber schwer verständlich. Mit
@@ -214,7 +214,7 @@ const title = 'Projekte & Portfolio'
         imageUrl="/images/projects/todos-preview.png"
       >
         <Fragment slot="description">
-          Eine Aufgabenverwaltung für Familien nach dem Prinzip „Bring Your Own
+          Eine Aufgabenverwaltung für Familien nach dem Prinzip „Bring your own
           LLM". Abhaken erledigt man ganz klassisch am Tablet – das ist der
           einfache Teil. Das Schwierige ist das Anlegen: wiederkehrende
           Aufgaben, verschiedene Tageszeiten, Zuweisungen. Dafür verbinden
@@ -225,8 +225,8 @@ const title = 'Projekte & Portfolio'
         <Fragment slot="motivation">
           <p>
             Dieses Projekt zeigt, dass Chat-LLMs die neuen Browser sind. Statt
-            User Interfaces für den Browser zu bauen, brauchen Apps in Zukunft
-            Machine Interfaces – Schnittstellen, die LLMs verstehen, inklusive
+            Benutzeroberflächen für den Browser zu bauen, brauchen Apps in Zukunft
+            Maschinen-Schnittstellen – Schnittstellen, die LLMs verstehen, inklusive
             Authentifizierung und Datenoperationen.
           </p>
           <p>


### PR DESCRIPTION
### Motivation
- Inhalte an mehreren zentralen Stellen idiomatischer und konsistenter auf Deutsch formulieren, da bisher vereinzelte wörtliche Übersetzungen aus dem Englischen verwendet wurden.
- Sichtbare UI-Texte im Gartenbereich (Fallback-Text, Paginierung) lokalisieren, damit Nutzerinnen und Nutzer ein einheitliches Deutsch sehen.
- Fachbegriffe und Schreibweisen (z. B. „Website“ vs. „Homepage“, „Frontend“, „Open Source“) vereinheitlichen, ohne die technische Aussage zu verändern.

### Description
- Überarbeitete Einleitung und Begriffe in `src/pages/de/index.mdx` (lesbarere Formulierung, „Software“ statt „Code“, `Astro`/`Content Collections` klar benannt). 
- Anpassungen in `src/pages/de/about.md` (Titel, Abschnittsüberschriften und mehrere Formulierungen für idiomatischeres Deutsch sowie vereinheitlichte Groß-/Kleinschreibung). 
- Glättung von Formulierungen in `src/pages/de/work.astro` (z. B. „Open-Source-Projekte“, „JWKS-Testserver“, „Integrationstests“, „Benutzeroberflächen“, „Maschinen-Schnittstellen“). 
- Lokalisierung von Garten-UI-Texten: Fallback-Text in `src/pages/[locale]/garden/plants/[...slug].astro` auf Deutsch und Pagination-Links in `src/pages/[locale]/garden/plants/[page].astro` von `Previous/Next` auf `Zurück/Weiter` geändert. 

### Testing
- `npx biome check src/pages/[locale]/garden/plants/[...slug].astro src/pages/[locale]/garden/plants/[page].astro src/pages/de/index.mdx src/pages/de/about.md src/pages/de/work.astro` wurde ausgeführt und meldete keine Fehler.
- `npm run build` wurde ausgeführt und erzeugte ein erfolgreiches statisches Build, wobei projektweite Vite-/CSS-Warnungen unverändert blieben (keine Build-Fehler).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaedaa451c8325a09cb5a00987430d)