### PR TITLE
Add prose-wide opt-out class for full-width content

### DIFF
--- a/src/pages/de/work.astro
+++ b/src/pages/de/work.astro
@@ -7,7 +7,7 @@ const title = 'Projekte & Portfolio'
 
 <Layout {title}>
   <div class="container mx-auto px-4 py-8">
-    <div class="prose max-w-none">
+    <div class="prose prose-wide max-w-none">
       <h2>Freelance Software-Entwicklung</h2>
       <p>
         Ich bin freier Software-Entwickler. Bitte sprechen Sie mich an, wenn Sie

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -77,8 +77,9 @@
   text-decoration: none;
 }
 
-/* Constrain blog post prose width for readability (overrides shipyard max-w-none) */
-.prose {
+/* Constrain blog post prose width for readability (overrides shipyard max-w-none).
+   Add `prose-wide` to opt out (e.g. for pages with full-width cards). */
+.prose:not(.prose-wide) {
   max-width: 75ch;
   margin-left: auto;
   margin-right: auto;


### PR DESCRIPTION
## Summary
This PR introduces a new `prose-wide` utility class that allows pages to opt out of the default prose width constraint, enabling full-width layouts for content like cards while maintaining the readability constraint on other pages.

## Changes
- Modified `.prose` selector to use `:not(.prose-wide)` pseudo-class, allowing the max-width constraint to be conditionally applied
- Updated the comment to document the new `prose-wide` opt-out mechanism with an example use case
- Applied `prose-wide` class to the German work/portfolio page (`de/work.astro`) to display full-width content

## Implementation Details
The change uses CSS `:not()` pseudo-class to exclude elements with the `prose-wide` class from the 75ch width constraint. This approach maintains backward compatibility while providing an escape hatch for pages that need full-width layouts (such as those with full-width cards or other wide content).

https://claude.ai/code/session_019JxuUaDFxhtad8tX2pBh2W