### PR TITLE
Link kreistag.levinkeller.de from homepage and nav

### DIFF
--- a/astro.config.js
+++ b/astro.config.js
@@ -61,6 +61,10 @@ export default defineConfig({
           label: 'Blog',
           href: '/blog',
         },
+        kreistag: {
+          label: 'Kreistag',
+          href: 'https://kreistag.levinkeller.de',
+        },
         work: {
           label: 'Levin',
           subEntry: {

--- a/src/pages/de/index.mdx
+++ b/src/pages/de/index.mdx
@@ -15,7 +15,7 @@ stimmig. Außerdem ermöglicht mir diese Seite ein bisschen mit
 [astro](https://astro.build/), content collections und MDX herumzuspielen, was
 interessant ist.
 
-<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+<div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
   <Card
     description="Ereignisse über die ich berichten möchte. Eindrücke und aktuelle Gedanken, die ich festhalten möchte."
     title="Blog"
@@ -25,5 +25,10 @@ interessant ist.
     title="Wissen"
     description="Dinge, die ich gelernt habe. Sachverhalte, die ich recherchiert habe."
     href="/de/docs"
+  />
+  <Card
+    title="Kreistag 2026"
+    description="Meine Kandidatur für den Kreistag Hildesheim, Wahlbereich B (Nordstemmen/Elze). Themen, Anfragen und laufende Recherche — öffentlich dokumentiert."
+    href="https://kreistag.levinkeller.de"
   />
 </div>


### PR DESCRIPTION
## Was ist drin

Verlinkt auf die neue Kandidaten-Seite [kreistag.levinkeller.de](https://kreistag.levinkeller.de) (Repo: [levino/kreistag](https://github.com/levino/kreistag), PR #1 dort) von zwei Stellen aus:

- **Startseite** (`src/pages/de/index.mdx`): dritte Card neben Blog und Wissen, mit Kurzbeschreibung der Kandidatur
- **Top-Navigation** (`astro.config.js`): neuer Eintrag „Kreistag" zwischen Blog und Levin

Grid auf der Startseite weitet sich auf `lg:grid-cols-3`, damit alle drei Karten auf Desktop in einer Reihe stehen; auf Tablet 2+1, mobil gestapelt.

## Test plan

- [ ] `npm run build` lokal grün
- [ ] Startseite zeigt drei Karten, die dritte verlinkt auf kreistag.levinkeller.de
- [ ] Nav-Eintrag „Kreistag" erscheint und öffnet ggf. extern (oder in neuem Tab — `<a>` ohne `target` öffnet im selben Tab; falls neues Tab gewünscht, sag Bescheid und ich passe an)

https://claude.ai/code/session_01JCdryZ7MCn3XBM1LNJHWqb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCdryZ7MCn3XBM1LNJHWqb)_